### PR TITLE
Caddy will run as root in the image.  This can be changed in the

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
-
+    commit-message:
+      prefix: ":seedling:"
+    assignees:
+      - "jquagga"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: ":seedling:"
+    assignees:
+      - "jquagga"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN git clone https://github.com/wiedehopf/tar1090.git tar1090
 FROM caddy:2@sha256:9fc94ed79892ca33b50bf9e548d6d639e6c8957b9e7b3965086dd754836903b6
 COPY --from=builder /web/tar1090/html/ /srv
 
-USER 65532
+#USER 65532
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
docker-compose, but without it, it's not possible to enable autohttps in the image. So while this isn't my preference; it can be configured either way.